### PR TITLE
Improve performance

### DIFF
--- a/JBAChallenge.xcodeproj/xcshareddata/xcschemes/JBAChallenge.xcscheme
+++ b/JBAChallenge.xcodeproj/xcshareddata/xcschemes/JBAChallenge.xcscheme
@@ -59,7 +59,7 @@
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"
-      shouldUseLaunchSchemeArgsEnv = "YES"
+      shouldUseLaunchSchemeArgsEnv = "NO"
       savedToolIdentifier = ""
       useCustomWorkingDirectory = "NO"
       debugDocumentVersioning = "YES">

--- a/JBAChallenge/JBAChallenge.xcdatamodeld/JBAChallenge.xcdatamodel/contents
+++ b/JBAChallenge/JBAChallenge.xcdatamodeld/JBAChallenge.xcdatamodel/contents
@@ -13,6 +13,7 @@
     </entity>
     <entity name="PrecipitationItem" representedClassName="PrecipitationItem" syncable="YES" codeGenerationType="class">
         <attribute name="date" optional="YES" attributeType="String"/>
+        <attribute name="fileName" optional="YES" attributeType="String"/>
         <attribute name="order" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
         <attribute name="value" optional="YES" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
         <attribute name="xref" optional="YES" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="YES"/>

--- a/JBAChallenge/JBAChallenge.xcdatamodeld/JBAChallenge.xcdatamodel/contents
+++ b/JBAChallenge/JBAChallenge.xcdatamodeld/JBAChallenge.xcdatamodel/contents
@@ -4,7 +4,6 @@
         <attribute name="fromYear" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="YES"/>
         <attribute name="name" attributeType="String"/>
         <attribute name="toYear" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="YES"/>
-        <relationship name="relationship" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="PrecipitationItem" inverseName="origin" inverseEntity="PrecipitationItem"/>
         <uniquenessConstraints>
             <uniquenessConstraint>
                 <constraint value="name"/>
@@ -14,10 +13,8 @@
     <entity name="PrecipitationItem" representedClassName="PrecipitationItem" syncable="YES" codeGenerationType="class">
         <attribute name="date" optional="YES" attributeType="String"/>
         <attribute name="fileName" optional="YES" attributeType="String"/>
-        <attribute name="order" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
         <attribute name="value" optional="YES" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
         <attribute name="xref" optional="YES" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="YES"/>
         <attribute name="yref" optional="YES" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="YES"/>
-        <relationship name="origin" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="FileItem" inverseName="relationship" inverseEntity="FileItem"/>
     </entity>
 </model>

--- a/JBAChallenge/JBAChallengeApp.swift
+++ b/JBAChallenge/JBAChallengeApp.swift
@@ -10,10 +10,10 @@ import SwiftUI
 @main
 struct JBAChallengeApp: App {
     let persistenceController = PersistenceController.shared
-    let rootViewModel: RootViewModel = .init()
     
     var body: some Scene {
         WindowGroup {
+            let rootViewModel: RootViewModel = .init()
             RootView(viewModel: rootViewModel)
         }
     }

--- a/JBAChallenge/Persistence.swift
+++ b/JBAChallenge/Persistence.swift
@@ -60,7 +60,7 @@ class PersistenceController {
         guard let requests = batchRequests[id], !requests.isEmpty else { throw Error.transactionNotExisted }
         
         let context = newBackgroundTaskContext()
-        try await context.perform { [weak self] in
+        try await context.perform {
             for request in requests {
                 let result = try context.execute(request)
                 print("result: \(result)")

--- a/JBAChallenge/Persistence.swift
+++ b/JBAChallenge/Persistence.swift
@@ -123,7 +123,7 @@ class PersistenceController {
         }
     }
     
-    func saveGrids(_ grids: [PrecipitationGridModel], withFileName fileName: String, fromYear: Int, toTransaction transactionId: String) {
+    func batchInsertGrids(_ grids: [PrecipitationGridModel], withFileName fileName: String, fromYear: Int, toTransaction transactionId: String) {
         var items: [[String: Any]] = []
         for grid in grids {
             for (yearOffset, row) in grid.rows.enumerated() {

--- a/JBAChallenge/Persistence.swift
+++ b/JBAChallenge/Persistence.swift
@@ -25,7 +25,7 @@ class PersistenceController {
         if inMemory {
             description.url = URL(fileURLWithPath: "/dev/null")
         }
-        print(description.url)
+        
         // Enable persistent store remote change notifications
         /// - Tag: persistentStoreRemoteChange
         description.setOption(true as NSNumber,
@@ -51,9 +51,7 @@ class PersistenceController {
     }
     
     func startTransaction() -> String {
-        let context = newBackgroundTaskContext()
-        let transactionId = UUID().uuidString
-        return transactionId
+        return UUID().uuidString
     }
     
     func submitTransaction(id: String) async throws {
@@ -63,10 +61,9 @@ class PersistenceController {
         try await context.perform {
             for request in requests {
                 let result = try context.execute(request)
-                print("result: \(result)")
             }
         }
-        print("transaction end =========")
+        
         updateBatchRequests(transactionId: id, batchRequest: nil)
     }
     

--- a/JBAChallenge/Root/RootView.swift
+++ b/JBAChallenge/Root/RootView.swift
@@ -57,11 +57,17 @@ struct RootView<ViewModel: RootViewModelProtocol>: View {
                         if !viewModel.items.isEmpty {
                             ItemCell(columns: ["Xref", "Yref", "Date", "Value"], isHeader: true)
                         }
-                        ForEach(viewModel.items) { item in
+                        
+                        ForEach(0..<viewModel.items.count, id: \.self) { index in
+                            let item = viewModel.items[index]
                             ItemCell(columns: ["\(item.xref)",
                                                "\(item.yref)",
                                                item.date ?? "",
                                                "\(item.value)"])
+                            .onAppear {
+                                guard index >= viewModel.items.count - 1 else { return }
+                                viewModel.fetchNextPage()
+                            }
                         }
                     }
                 }

--- a/JBAChallenge/Root/RootViewModel.swift
+++ b/JBAChallenge/Root/RootViewModel.swift
@@ -40,7 +40,6 @@ class RootViewModel: RootViewModelProtocol {
         let transactionId = dataController.startTransaction()
         
         do {
-            dataController.batchDeleteGridRows(inFile: fileName, toTransaction: transactionId)
             
             var currentGrid: PrecipitationGridModel?
             var fromYear = 0
@@ -51,6 +50,10 @@ class RootViewModel: RootViewModelProtocol {
                     if let yearString = scan(headerString: line)["Years"],
                        let years = try findYears(string: yearString) {
                         fromYear = years.from
+                        dataController.saveFile(name: fileName,
+                                                fromYear: Int16(years.from),
+                                                toYear: Int16(years.to),
+                                                toTransaction: transactionId)
                     }
                     continue
                 }
@@ -70,6 +73,7 @@ class RootViewModel: RootViewModelProtocol {
             }
             
             
+            dataController.batchDeleteGridRows(inFile: fileName, toTransaction: transactionId)
             dataController.batchInsertGrids(grids, withFileName: fileName, fromYear: fromYear, toTransaction: transactionId)
             
             try await dataController.submitTransaction(id: transactionId)

--- a/JBAChallenge/Root/RootViewModel.swift
+++ b/JBAChallenge/Root/RootViewModel.swift
@@ -100,10 +100,21 @@ class RootViewModel: RootViewModelProtocol {
                     fetchRequest.predicate = NSPredicate(format: "fileName == %@", file)
                     fetchRequest.fetchLimit = 12
                     self.items = try context.fetch(fetchRequest)
-                    if let file = self.items.first?.origin {
-                        self.header = "Years: \(file.fromYear)-\(file.toYear) (count: \(self.items.count))"
-                    }
+                    
                     self.currentFetch = fetchRequest
+                    
+                    //count
+                    let countFetchRequest = PrecipitationItem.fetchRequest()
+                    countFetchRequest.predicate = fetchRequest.predicate
+                    let count = try context.count(for: countFetchRequest)
+                    
+                    //header
+                    let fileFetchRequest = FileItem.fetchRequest()
+                    fileFetchRequest.predicate = NSPredicate(format: "name == %@", file)
+                   
+                    if let file = try context.fetch(fileFetchRequest).first {
+                        self.header = "Years: \(file.fromYear)-\(file.toYear) (count: \(count))"
+                    }
                 }
             } catch {
                 errorMessage = "Fetch data failed.\n\(error.localizedDescription)"

--- a/JBAChallenge/Root/RootViewModel.swift
+++ b/JBAChallenge/Root/RootViewModel.swift
@@ -69,7 +69,8 @@ class RootViewModel: RootViewModelProtocol {
                 grids.append(currentGrid)
             }
             
-            dataController.saveGrids(grids, withFileName: fileName, fromYear: fromYear, toTransaction: transactionId)
+            
+            dataController.batchInsertGrids(grids, withFileName: fileName, fromYear: fromYear, toTransaction: transactionId)
             
             try await dataController.submitTransaction(id: transactionId)
 //            fetchFiles()


### PR DESCRIPTION
1. Used batch delete/insert instead of modifying by manipulating a single data item.
2. Removed the relationship between FileItem and PrecipitationItem.
3. Added pagination when fetching grid data.
4. Added a synchronised queue to maintain the BatchRequest dictionary. Keep it to be thread-safe.